### PR TITLE
Update Aluminium OPAM files

### DIFF
--- a/opam/frama-c/descr
+++ b/opam/frama-c/descr
@@ -1,11 +1,16 @@
-Platform dedicated to the static analysis of source code written in C
-Frama-C is a suite of tools dedicated to the analysis of the source
-code of software written in C. Magnesium version.
+Platform dedicated to the analysis of source code written in C. Aluminium version.
 
-Frama-C gathers several static analysis techniques in a single
-collaborative framework. The collaborative approach of Frama-C allows
-static analyzers to build upon the results already computed by other
-analyzers in the framework. Thanks to this approach, Frama-C provides
-sophisticated tools, such as a slicer and dependency analysis.
+Frama-C gathers several analysis techniques in a single collaborative
+framework, based on analyzers (called "plug-ins") that can build upon the
+results computed by other analyzers in the framework.
+Thanks to this approach, Frama-C provides sophisticated tools, including:
+- an analyzer based on abstract interpretation (Value plug-in);
+- a program proof framework based on weakest precondition calculus (WP plug-in);
+- a program slicer (Slicing plug-in);
+- a tool for verification of temporal (LTL) properties (Aoraï plug-in);
+- several tools for code base exploration and dependency analysis
+  (plug-ins From, Impact, Metrics, Occurrence, Scope, etc.).
+These plug-ins communicate between each other via the Frama-C API
+and via ACSL (ANSI/ISO C Specification Language) properties.
 
 This virtual package forces the installation of frama-C with its IDE.

--- a/opam/frama-c/opam
+++ b/opam/frama-c/opam
@@ -8,12 +8,14 @@ authors: [
   "Richard Bonichon"
   "David Bühler"
   "Loïc Correnson"
+  "Julien Crétin"
   "Pascal Cuoq"
   "Zaynah Dargaye"
   "Jean-Christophe Filliâtre"
   "Philippe Herrmann"
   "Florent Kirchner"
   "Matthieu Lemerre"
+  "David Maison"
   "Claude Marché"
   "André Maroneze"
   "Benjamin Monate"
@@ -29,7 +31,8 @@ authors: [
 ]
 homepage: "http://frama-c.com/"
 license: "GNU Lesser General Public License version 2.1"
-doc: ["http://frama-c.com/download/user-manual-Magnesium-20151002.pdf"]
+dev-repo: "https://github.com/Frama-C/Frama-C-snapshot.git"
+doc: ["http://frama-c.com/download/user-manual-Aluminium-20160501.pdf"]
 bug-reports: "https://bts.frama-c.com/"
 tags: [
   "deductive"
@@ -58,4 +61,5 @@ depends: [
 messages: [
    "Alt-Ergo Graphical Interface can be used by the WP plug-in" { !altgr-ergo:installed }
 ]
-available: [ ocaml-version >= "3.12" & ocaml-version != "4.02.0" ]
+available: [ ocaml-version >= "4.00.1" & ocaml-version != "4.02.0" &
+             ocaml-version != "4.02.2" ]

--- a/opam/opam
+++ b/opam/opam
@@ -31,7 +31,8 @@ authors: [
 ]
 homepage: "http://frama-c.com/"
 license: "GNU Lesser General Public License version 2.1"
-doc: ["http://frama-c.com/download/user-manual-Magnesium-20151002.pdf"]
+dev-repo: "https://github.com/Frama-C/Frama-C-snapshot.git"
+doc: ["http://frama-c.com/download/user-manual-Aluminium-20160501.pdf"]
 bug-reports: "https://bts.frama-c.com/"
 tags: [
   "deductive"
@@ -56,7 +57,7 @@ build: [
                  "--disable-gui" { !conf-gtksourceview:installed |
                                    !conf-gnomecanvas:installed }
 ]
-  [make]
+  [make "-j%{jobs}%"]
 ]
 
 install: [
@@ -81,7 +82,7 @@ build-doc: [
 ]
 
 build-test: [
-  [make "PTESTS_OPTS=-error-code" "tests"]
+  [make "-j%{jobs}%" "PTESTS_OPTS=-error-code" "tests"]
 ]
 
 depends: [


### PR DESCRIPTION
This update is recommended to avoid mismatches between the OPAM files in `opam-repository` and the ones here. Especially now that this repository is marked as `dev-repo`, having different OPAM files will probably cause issues.

The unfortunate consequence is that this repository will no longer match 100% the released tar.gz archive. But I still think that it's better to update it.