### PR TITLE
Repair and reactivate why3ide

### DIFF
--- a/src/plugins/wp/GuiNavigator.ml
+++ b/src/plugins/wp/GuiNavigator.ml
@@ -239,11 +239,9 @@ class behavior
           Task.spawn server thread ;
           Task.launch server in
         match prover with
-        (*
         | VCS.Why3ide ->
             let iter f = Wpo.iter ~on_goal:f () in
             schedule (ProverWhy3ide.prove ~callback:result ~iter)
-        *)
         | VCS.Tactical ->
             begin
               match mode , ProverScript.get w with
@@ -303,12 +301,10 @@ class behavior
       match popup_target with
       | Some(w,Some p) -> (popup_target <- None ; self#prove ~mode w p)
       | _ -> popup_target <- None
-(*
     method private popup_why3ide () =
       match popup_target with
       | Some(w,_) -> (popup_target <- None ; self#prove w VCS.Why3ide)
       | _ -> popup_target <- None
-*)
     method private add_popup_delete popup =
       begin
         popup#add_separator ;
@@ -333,13 +329,11 @@ class behavior
           [ "Run",BatchMode ; "Open Altgr-Ergo on Fail",EditMode ; "Open Altgr-Ergo",EditMode ] ;
         self#add_popup_proofmodes popup_coq
           [ "Check Proof",BatchMode ; "Edit on Fail",EditMode ; "Edit Proof",EditMode ] ;
-        (*
         List.iter
           (fun menu ->
              menu#add_item ~label:"Open Why3ide" ~callback:self#popup_why3ide ;
              self#add_popup_delete menu ;
           ) [ popup_qed ; popup_why3 ; popup_ergo ; popup_coq ] ;
-        *)
       end
 
     method private popup w p =

--- a/src/plugins/wp/VCS.ml
+++ b/src/plugins/wp/VCS.ml
@@ -31,7 +31,7 @@ let dkey_success_only = Wp_parameters.register_category "success-only"
 
 type prover =
   | Why3 of string (* Prover via WHY *)
-  (*  | Why3ide  *)
+  | Why3ide
   | AltErgo       (* Alt-Ergo *)
   | Coq           (* Coq and Coqide *)
   | Qed           (* Qed Solver *)
@@ -54,16 +54,16 @@ let prover_of_name = function
   | "coq" | "coqide" -> Some Coq
   | "script" -> Some Tactical
   | "tip" -> Some Tactical
-  (* | "why3ide" -> Some Why3ide *)
+  | "why3ide" -> Some Why3ide
   | s ->
       match Extlib.string_del_prefix "why3:" s with
       | Some "" -> None
-      (* | Some "ide" -> Some Why3ide*)
+      | Some "ide" -> Some Why3ide
       | Some s' -> Some (Why3 s')
       | None -> Some (Why3 s)
 
 let name_of_prover = function
-  (*  | Why3ide -> "why3ide" *)
+  | Why3ide -> "why3ide"
   | Why3 s -> "why3:" ^ s
   | AltErgo -> "alt-ergo"
   | Coq -> "coq"
@@ -75,7 +75,7 @@ let title_of_prover = function
   | Why3 "z3" -> "Z3"
   | Why3 ("alt-ergo" | "altergo") -> "Alt-Ergo (why3)"
   | Why3 s -> Printf.sprintf "Why3 (%s)" s
-  (*  | Why3ide -> "Why3 (ide)" *)
+  | Why3ide -> "Why3 (ide)"
   | AltErgo -> "Alt-Ergo"
   | Coq -> "Coq"
   | Qed -> "Qed"
@@ -102,7 +102,7 @@ let sanitize_why3 s =
 
 let filename_for_prover = function
   | Why3 s -> sanitize_why3 s
-  (*  | Why3ide -> "Why3_ide" *)
+  | Why3ide -> "Why3_ide"
   | AltErgo -> "Alt-Ergo"
   | Coq -> "Coq"
   | Qed -> "Qed"
@@ -110,7 +110,7 @@ let filename_for_prover = function
 
 let language_of_prover = function
   | Why3 _ -> L_why3
-  (*  | Why3ide -> L_why3 *)
+  | Why3ide -> L_why3
   | Coq -> L_coq
   | AltErgo -> L_altergo
   | Qed | Tactical -> L_why3

--- a/src/plugins/wp/VCS.mli
+++ b/src/plugins/wp/VCS.mli
@@ -28,6 +28,7 @@
 
 type prover =
   | Why3 of string (* Prover via WHY *)
+  | Why3ide       (* why3 ide *)
   | AltErgo       (* Alt-Ergo *)
   | Coq           (* Coq and Coqide *)
   | Qed           (* Qed Solver *)

--- a/src/plugins/wp/register.ml
+++ b/src/plugins/wp/register.ml
@@ -513,10 +513,8 @@ let compute_provers ~mode =
       (fun pname prvs ->
          match VCS.prover_of_name pname with
          | None -> prvs
-         (*
          | Some VCS.Why3ide ->
              mode.why3ide <- true; prvs
-         *)
          | Some VCS.Tactical ->
              mode.tactical <- true ;
              if pname = "tip" then mode.update <- true ;
@@ -628,10 +626,8 @@ let do_wp_proofs_iter iter =
   let spawned = mode.why3ide || mode.tactical || mode.provers <> [] in
   begin
     if spawned then do_list_scheduled iter ;
-    (*
     if mode.why3ide then
       launch (ProverWhy3ide.prove ~callback:do_why3_result ~iter) ;
-    *)
     spawn_wp_proofs_iter ~mode iter ;
     if spawned then
       begin


### PR DESCRIPTION
Adapt frama-c to understand changes to why3 ide xml format. Pass output
directory correctly to why3 ide so it does not error on startup. Reactivate
support for why3 ide commented out in various places.

Tested with why3 version 1.2.1.