### PR TITLE
Add support for aarch64

### DIFF
--- a/share/libc/__fc_machdep.h
+++ b/share/libc/__fc_machdep.h
@@ -114,16 +114,18 @@
 
 // End of X86_32 || GCC_X86_32
 #else
-#if defined(__FC_MACHDEP_X86_64) || defined(__FC_MACHDEP_GCC_X86_64)
+#if defined(__FC_MACHDEP_X86_64) || defined(__FC_MACHDEP_GCC_X86_64) || defined(__FC_MACHDEP_AARCH64) || defined(__FC_MACHDEP_GCC_AARCH64)
 #define __FC_FORCE_INCLUDE_MACHDEP__
 #include "__fc_machdep_linux_shared.h"
-#ifdef __FC_MACHDEP_GCC_X86_64
+#if defined(__FC_MACHDEP_GCC_X86_64) || defined(__FC_MACHDEP_GCC_AARCH64)
 #include "__fc_gcc_builtins.h"
 #endif
 #undef __FC_FORCE_INCLUDE_MACHDEP__
 #define  __FC_BYTE_ORDER __LITTLE_ENDIAN
 /* Required */
+#if defined(__FC_MACHDEP_X86_64) || defined(__FC_MACHDEP_GCC_X86_64)
 #undef  __CHAR_UNSIGNED__
+#endif
 #define __WORDSIZE 64
 #define __SIZEOF_SHORT 2
 #define __SIZEOF_INT 4
@@ -638,7 +640,7 @@
 #else
 #error Must define __FC_MACHDEP_<M>, where <M> is one of the            \
   following: X86_32, X86_64, X86_16, GCC_X86_32, GCC_X86_64,            \
-  GCC_X86_16, PPC_32, MSVC_X86_64.                                      \
+  GCC_X86_16, PPC_32, MSVC_X86_64, AARCH64, GCC_AARCH64.	         \
   If you are using a custom machdep, you must include your machdep      \
   header file defining __FC_MACHDEP to avoid inclusion of this file.
 #endif

--- a/src/kernel_internals/runtime/machdeps.ml
+++ b/src/kernel_internals/runtime/machdeps.ml
@@ -169,6 +169,17 @@ let gcc_x86_64 = { x86_64 with
                    sizeof_fun = 1; alignof_fun = 1;
                  }
 
+let aarch64 = { x86_64 with
+                   version = "gcc 8.2.0 aarch64-linux-gnu";
+                   cpp_arch_flags = [];
+                   char_is_unsigned = true;
+                 }
+
+let gcc_aarch64 = { aarch64 with
+                   version = "gcc";
+                   sizeof_fun = 1; alignof_fun = 1;
+                 }
+
 let ppc_32 = {
   version          = "4.0.1 (Apple Computer, Inc. build 5367)";
   compiler         = "standard";

--- a/src/kernel_internals/runtime/machdeps.mli
+++ b/src/kernel_internals/runtime/machdeps.mli
@@ -50,5 +50,7 @@ val x86_32: Cil_types.mach
 val gcc_x86_32: Cil_types.mach
 val x86_64: Cil_types.mach
 val gcc_x86_64: Cil_types.mach
+val aarch64: Cil_types.mach
+val gcc_aarch64: Cil_types.mach
 val ppc_32: Cil_types.mach
 val msvc_x86_64: Cil_types.mach

--- a/src/kernel_services/ast_queries/file.ml
+++ b/src/kernel_services/ast_queries/file.ml
@@ -297,6 +297,8 @@ let default_machdeps =
     "gcc_x86_16", Machdeps.x86_16;
     "gcc_x86_32", Machdeps.gcc_x86_32;
     "gcc_x86_64", Machdeps.gcc_x86_64;
+    "aarch64", Machdeps.aarch64;
+    "gcc_aarch64", Machdeps.gcc_aarch64;
     "ppc_32", Machdeps.ppc_32;
     "msvc_x86_64", Machdeps.msvc_x86_64;
   ]
@@ -317,6 +319,8 @@ let machdep_macro = function
   | "gcc_x86_32"            -> "__FC_MACHDEP_GCC_X86_32"
   | "x86_64"                -> "__FC_MACHDEP_X86_64"
   | "gcc_x86_64"            -> "__FC_MACHDEP_GCC_X86_64"
+  | "aarch64"               -> "__FC_MACHDEP_AARCH64"
+  | "gcc_aarch64"           -> "__FC_MACHDEP_GCC_AARCH64"
   | "ppc_32"                -> "__FC_MACHDEP_PPC_32"
   | "msvc_x86_64"           -> "__FC_MACHDEP_MSVC_X86_64"
   | s ->


### PR DESCRIPTION
Added support for aarch64 and gcc_aarch64 machdeps.
ARM v8 CPU are almost everywhere, they should be in Frama-C too !